### PR TITLE
feat: SpringSecurity를 위한 MemberType 생성

### DIFF
--- a/src/main/java/com/luckyvicky/woosan/domain/member/entity/MemberType.java
+++ b/src/main/java/com/luckyvicky/woosan/domain/member/entity/MemberType.java
@@ -1,0 +1,24 @@
+package com.luckyvicky.woosan.domain.member.entity;
+
+public enum MemberType {
+    USER(Level.class), GUEST, ADMIN;
+
+    // 레벨 클래스를 저장하기 위한 필드 (USER에만 적용됨)
+    private Class<? extends Enum<?>> levelCLass;
+
+    MemberType() {
+        this.levelCLass = null;
+    }
+
+    MemberType(Class<? extends Enum<?>> levelCLass) {
+        this.levelCLass = levelCLass;   // levelClass 초기화
+    }
+
+    public Class<? extends Enum<?>> getLevelCLass() {
+        return levelCLass;  // 연관된 레벨 클래스 반환
+    }
+
+    public enum Level {
+        LEVEL_1, LEVEL_2, LEVEL_3, LEVEL_4, LEVEL_5;
+    }
+}


### PR DESCRIPTION
- SpringSecurity 설정 및 멤버 구분을 위한 MemberType 생성
- enum으로 생성
- USER인 경우 Level로 구분이 가능해야 하므로 하위 enum 역시 생성