### PR TITLE
feat: Member, MemberProfile, MemberType, SocialType enum, MBTI enum 생성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,9 +36,6 @@ dependencies {
 	testCompileOnly 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'
 
-	// mybatis
-	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.0'
-
 	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}:jakarta"
 
 	implementation 'org.modelmapper:modelmapper:3.1.0'
@@ -48,7 +45,7 @@ dependencies {
 	implementation 'net.coobird:thumbnailator:0.4.16'
 
 	// spring security
-//	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 
 	annotationProcessor(
 			"com.querydsl:querydsl-apt:5.0.0:jakarta",

--- a/src/main/java/com/luckyvicky/woosan/domain/member/entity/MBTI.java
+++ b/src/main/java/com/luckyvicky/woosan/domain/member/entity/MBTI.java
@@ -1,0 +1,6 @@
+package com.luckyvicky.woosan.domain.member.entity;
+
+public enum MBTI {
+    ISTJ, ISFJ, INFJ, INTJ, ISTP, ISFP, INFP, INTP,
+    ESTP, ESFP, ENFP, ENTP, ESTJ, ESFJ, ENFJ, ENTJ
+}

--- a/src/main/java/com/luckyvicky/woosan/domain/member/entity/Member.java
+++ b/src/main/java/com/luckyvicky/woosan/domain/member/entity/Member.java
@@ -8,7 +8,7 @@ import org.hibernate.annotations.DynamicUpdate;
 @Entity
 @Getter
 @Builder
-@AllArgsConstructor
+@AllArgsConstructor // USER 사용
 @NoArgsConstructor
 @ToString
 @DynamicUpdate
@@ -33,10 +33,24 @@ public class Member {
     @Enumerated(EnumType.STRING)
     private MemberType memberType;
 
+    @Enumerated(EnumType.STRING)
+    private MemberType.Level level;
+
     @ColumnDefault("true")
     private Boolean isActive;
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private SocialType socialType;
+
+    // level 필드를 제외한 생성자(ADMIN, GUEST 사용)
+    public Member(String email, String nickname, String password, Long point, MemberType memberType, Boolean isActive, SocialType socialType) {
+        this.email = email;
+        this.nickname = nickname;
+        this.password = password;
+        this.point = point;
+        this.memberType = memberType;
+        this.isActive = isActive;
+        this.socialType = socialType;
+    }
 }

--- a/src/main/java/com/luckyvicky/woosan/domain/member/entity/Member.java
+++ b/src/main/java/com/luckyvicky/woosan/domain/member/entity/Member.java
@@ -20,15 +20,23 @@ public class Member {
     @Column(nullable = false, unique = true)
     private String email;
 
+    @Column(nullable = false, unique = true)
+    private String nickname;
+
     @Column(nullable = false)
     private String password;
 
     @ColumnDefault("0")
     private Long point;
 
-    @ColumnDefault("1")
-    private Long grade;
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private MemberType memberType;
 
     @ColumnDefault("true")
     private Boolean isActive;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private SocialType socialType;
 }

--- a/src/main/java/com/luckyvicky/woosan/domain/member/entity/MemberProfile.java
+++ b/src/main/java/com/luckyvicky/woosan/domain/member/entity/MemberProfile.java
@@ -1,4 +1,44 @@
 package com.luckyvicky.woosan.domain.member.entity;
 
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+@DynamicUpdate
 public class MemberProfile {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Column
+    private String phone;
+
+    @Column
+    private String location;
+
+    @Column
+    private String introduce;
+
+    @Column
+    @Enumerated(EnumType.STRING)
+    private MBTI mbti;
+
+    @Column
+    private String gender;
+
+    @Column
+    private int age;
+
+    @Column
+    private int height;
 }

--- a/src/main/java/com/luckyvicky/woosan/domain/member/entity/MemberType.java
+++ b/src/main/java/com/luckyvicky/woosan/domain/member/entity/MemberType.java
@@ -1,0 +1,24 @@
+package com.luckyvicky.woosan.domain.member.entity;
+
+public enum MemberType {
+    USER(Level.class), GUEST, ADMIN;
+
+    // 레벨 클래스를 저장하기 위한 필드 (USER에만 적용됨)
+    private Class<? extends Enum<?>> levelCLass;
+
+    MemberType() {
+        this.levelCLass = null;
+    }
+
+    MemberType(Class<? extends Enum<?>> levelCLass) {
+        this.levelCLass = levelCLass;   // levelClass 초기화
+    }
+
+    public Class<? extends Enum<?>> getLevelCLass() {
+        return levelCLass;  // 연관된 레벨 클래스 반환
+    }
+
+    public enum Level {
+        LEVEL_1, LEVEL_2, LEVEL_3, LEVEL_4, LEVEL_5;
+    }
+}

--- a/src/main/java/com/luckyvicky/woosan/domain/member/entity/SocialType.java
+++ b/src/main/java/com/luckyvicky/woosan/domain/member/entity/SocialType.java
@@ -1,0 +1,5 @@
+package com.luckyvicky.woosan.domain.member.entity;
+
+public enum SocialType {
+    NORMAL, KAKAO, NAVER, GOOGLE
+}


### PR DESCRIPTION
-  Member: 누락된 필드(nickname, socialType) 추가 및 level 필드 생성
- MemberProfile: entity 생성
- MemberType: 유저(레벨1~5), 회원
- SocialType: Member에서 사용할 소셜로그인 여부 확인할 enum
- MBTI: MemberType에서 사용할 MBTI enum 생성