### PR TITLE
feat: refreshToken 이용해서 accessToken 재발급 받는 방식 변경, accessToken 유효 시간 변경, 토큰 관련 예외 처리

### DIFF
--- a/src/main/java/com/luckyvicky/woosan/domain/member/dto/LoginResponseDTO.java
+++ b/src/main/java/com/luckyvicky/woosan/domain/member/dto/LoginResponseDTO.java
@@ -12,6 +12,6 @@ public class LoginResponseDTO {
     public LoginResponseDTO(String accessToken, String refreshToken) {
         this.accessToken = accessToken;
         this.refreshToken = refreshToken;
-        this.expirationTime = 3600000;
+        this.expirationTime = 60000;
     }
 }

--- a/src/main/java/com/luckyvicky/woosan/global/auth/controller/AuthController.java
+++ b/src/main/java/com/luckyvicky/woosan/global/auth/controller/AuthController.java
@@ -2,17 +2,24 @@ package com.luckyvicky.woosan.global.auth.controller;
 
 import com.luckyvicky.woosan.domain.member.dto.LoginRequestDTO;
 import com.luckyvicky.woosan.domain.member.dto.LoginResponseDTO;
+import com.luckyvicky.woosan.domain.member.entity.Member;
+import com.luckyvicky.woosan.domain.member.mapper.MemberMapper;
+import com.luckyvicky.woosan.domain.member.repository.MemberRepository;
+import com.luckyvicky.woosan.global.auth.dto.RefreshTokenReqDTO;
+import com.luckyvicky.woosan.global.auth.dto.RefreshTokenResDTO;
+import com.luckyvicky.woosan.global.auth.exception.JWTException;
+import com.luckyvicky.woosan.global.auth.filter.JWTUtil;
 import com.luckyvicky.woosan.global.auth.service.AuthService;
+import com.luckyvicky.woosan.global.exception.ErrorCode;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -31,4 +38,10 @@ public class AuthController {
         response.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
         return ResponseEntity.status(HttpStatus.OK).body(dto);
     }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<?> refreshAccessToken(@RequestHeader("Authorization") String authHeader, @RequestBody RefreshTokenReqDTO request) {
+        return authService.refreshAccessToken(authHeader, request);
+    }
+
 }

--- a/src/main/java/com/luckyvicky/woosan/global/auth/dto/RefreshTokenReqDTO.java
+++ b/src/main/java/com/luckyvicky/woosan/global/auth/dto/RefreshTokenReqDTO.java
@@ -1,0 +1,12 @@
+package com.luckyvicky.woosan.global.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class RefreshTokenReqDTO {
+    private String refreshToken;
+}

--- a/src/main/java/com/luckyvicky/woosan/global/auth/dto/RefreshTokenResDTO.java
+++ b/src/main/java/com/luckyvicky/woosan/global/auth/dto/RefreshTokenResDTO.java
@@ -1,0 +1,11 @@
+package com.luckyvicky.woosan.global.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class RefreshTokenResDTO {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/luckyvicky/woosan/global/auth/exception/JWTException.java
+++ b/src/main/java/com/luckyvicky/woosan/global/auth/exception/JWTException.java
@@ -1,0 +1,10 @@
+package com.luckyvicky.woosan.global.auth.exception;
+
+import com.luckyvicky.woosan.global.exception.ErrorCode;
+import com.luckyvicky.woosan.global.exception.GlobalException;
+
+public class JWTException extends GlobalException {
+    public JWTException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/luckyvicky/woosan/global/auth/filter/JwtAuthFilter.java
+++ b/src/main/java/com/luckyvicky/woosan/global/auth/filter/JwtAuthFilter.java
@@ -55,11 +55,6 @@ public class JwtAuthFilter extends OncePerRequestFilter {
                     // 현재 Request의 Security Context에 접근권한 설정
                     SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);
                 }
-            } else {
-                String email = jwtUtil.getEmail(token);
-                Member member = memberRepository.findByEmail(email);
-                String newAccessToken = jwtUtil.createAccessToken(memberMapper.memberToCustomUserInfoDTO(member));
-                response.setHeader("Authorization", "Bearer " + newAccessToken);
             }
         }
 

--- a/src/main/java/com/luckyvicky/woosan/global/auth/service/AuthService.java
+++ b/src/main/java/com/luckyvicky/woosan/global/auth/service/AuthService.java
@@ -3,10 +3,13 @@ package com.luckyvicky.woosan.global.auth.service;
 import com.luckyvicky.woosan.domain.member.dto.LoginRequestDTO;
 import com.luckyvicky.woosan.domain.member.dto.LoginResponseDTO;
 import com.luckyvicky.woosan.global.auth.dto.CustomUserInfoDTO;
+import com.luckyvicky.woosan.global.auth.dto.RefreshTokenReqDTO;
+import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
 public interface AuthService {
     LoginResponseDTO login(LoginRequestDTO dto);
     CustomUserInfoDTO getKakaoMember(String accessToken);
+    ResponseEntity<?> refreshAccessToken(String authHeader, RefreshTokenReqDTO request);
 }

--- a/src/main/java/com/luckyvicky/woosan/global/exception/ErrorCode.java
+++ b/src/main/java/com/luckyvicky/woosan/global/exception/ErrorCode.java
@@ -36,7 +36,12 @@ public enum ErrorCode {
     IMAGE_FORMAT_ERROR(HttpStatus.BAD_REQUEST, "지원하지 않는 이미지 포맷입니다."),
 
     // 추천 관련 오류
-    LIKES_COUNT_NEGATIVE(HttpStatus.BAD_REQUEST, "추천 수는 음수가 될 수 없습니다.");
+    LIKES_COUNT_NEGATIVE(HttpStatus.BAD_REQUEST, "추천 수는 음수가 될 수 없습니다."),
+
+    // jwt 관련 오류
+    ACCESS_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "Access Token이 존재하지 않습니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "Refresh Token이 존재하지 않습니다."),
+    INVALID_STRING(HttpStatus.BAD_REQUEST, "Invalid String");
 
     private final HttpStatus status;
     private final String message;


### PR DESCRIPTION
- JwtAuthFilter에서 서버 실행 시 자동으로 accessToken 재발급 받는 코드 삭제
- AuthService, Impl, AuthController에 refreshtoken을 이용해 accessToken 재발급 받는 코드 추가
- LoginResponseDTO에서 accessToken 유효 시간 변경
- JWTException 생성해 토큰 관련 에러 처리